### PR TITLE
CDAP-15756 GoogleCloudSpannerTest broken due to pubsub dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
       <version>0.53.0-beta</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>opencensus-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Following tests was executed successfully:

- GCSTest
- PubSubTest
- GoogleCloudSpannerTest(suffers from hbase client conflicts, but job submitted, this PR fixes inability to start GoogleCloudSpannerTest)